### PR TITLE
Add sample-profile.js

### DIFF
--- a/sample-profile.js
+++ b/sample-profile.js
@@ -1,0 +1,14 @@
+module.exports = [{
+	host: 'chat.freenode.net',
+	port: 6667,
+	user: process.env.USER,
+	nick: 'botname',
+	real: 'Description of bot',
+
+	nickserv: 'Example',
+	password: 'password',
+
+	channels: [
+		'#example'
+	]
+}];


### PR DESCRIPTION
Though a plain object example exists in `your-bot-here.js`. Most actual bots (both in this repo and in forks) use the separate `-profile.js` file and require it. This is an example to show what that file might look like. Makes it easier to get set up (both for myself and others).
