### PR TITLE
Ensures control characters and colours are stripped before parsing.

### DIFF
--- a/lib/irc/client.js
+++ b/lib/irc/client.js
@@ -96,6 +96,7 @@ Client.prototype.nick = function(nick) {
 
 
 Client.prototype.parse = function(incoming) {
+	incoming  = this.strip_color(this.strip_control(incoming))
 	var match = incoming.match(/(?:(:[^\s]+) )?([^\s]+) (.+)/);
 
 	var msg, params = match[3].match(/(.*?) ?:(.*)/);


### PR DESCRIPTION
This should be a no-issue on the Freenode network, but on other networks people
often use colours and such, so those people can not interact with the
bot. Given that such control characters are just intended for humans, removing
them before parsing makes sense.
