### PR TITLE
Do not allow users to !learn something to a facctoid alias

### DIFF
--- a/lib/factoidserv/index.js
+++ b/lib/factoidserv/index.js
@@ -37,7 +37,7 @@ FactoidServer.prototype.learn = function(key, value, username) {
 
 	if (typeof db[key] !== "undefined") {
 		if (typeof db[key].alias !== "undefined") {
-			return this.learn(db[key].alias, value, username);
+			throw new Error('`' + key + '` is an alias for `' + db[key].alias + '`. No changes applied.');
 		}
 		creator = db[key].creator;
 		editors = db[key].editors || editors;


### PR DESCRIPTION
The issue was that a user `!learn`d a new factoid with the name of an alias (probably not knowing it the alias even existed) and overwrote the original factoid that the alias pointed to. We should disallow this and require changes to a factoid to be done directly on the _real_ factoid.
