### PR TITLE
Fix possible V8 vulnerability using `prepareStackTrace`

### DIFF
--- a/lib/sandbox/v8/shovel.js
+++ b/lib/sandbox/v8/shovel.js
@@ -57,8 +57,13 @@ var Sandbox = (function() {
 	Sandbox.prototype.execute = function() {
 		if (typeof this.utils_global.global !== "object")
 			throw new Error("Expected global to be an object.");
-	
-		return vm.runInNewContext(this.input_code, this.utils_global.global, "irc");
+
+		// We have to remove the Error object's captureStackTrace function
+		// or an exploit might be possible in V8 - thanks to `Benvie`
+		var context = vm.createContext(this.utils_global.global);
+		vm.runInContext("delete Error.captureStackTrace;", context, "irc");
+
+		return vm.runInContext(this.input_code, context, "irc");
 	};
 	
 	Sandbox.report_error = function(error) {


### PR DESCRIPTION
Benvie pointed out that allowing the stack tracing utility functions allows a user to break out of the inner context and gain access to the full node.js process. While this will still be limited by the timeout, this is still a huge security hole. This is my first attempt to patch that hole.

I tried a lot of little things myself but I don't know if this truly fixes the issue. To feel comfortable, I would like @Benvie to hammer on it with his expertise.
