### PR TITLE
Add custom toString function to setTimeout and clearTimeout

### DIFF
--- a/ecmabot-utils.js
+++ b/ecmabot-utils.js
@@ -259,6 +259,15 @@ function executeTimeouts() {
 	}
 }
 
+var pretendToBeNativeCode = function toString () {
+	var name = this && this.name;
+	return name ? "function " + name + "() { [native code] }" : "";
+};
+
+Object.defineProperty(pretendToBeNativeCode, "toString", {
+	value: pretendToBeNativeCode
+});
+
 Object.defineProperty(global, "setTimeout", {
 	value: function setTimeout(fn, delay) {
 		var runOrder = Date.now() + delay,
@@ -282,6 +291,10 @@ Object.defineProperty(global, "setTimeout", {
 	enumerable: true
 });
 
+Object.defineProperty(global.setTimeout, "toString", {
+	value: pretendToBeNativeCode
+});
+
 Object.defineProperty(global, "clearTimeout", {
 	value: function clearTimeout(handle) {
 		var l = timerQueue.length;
@@ -294,6 +307,10 @@ Object.defineProperty(global, "clearTimeout", {
 		}
 	},
 	enumerable: true
+});
+
+Object.defineProperty(global.clearTimeout, "toString", {
+	value: pretendToBeNativeCode
 });
 
 // The built-ins in this context should not be changed.


### PR DESCRIPTION
The idea is to make them look like native function. Right now if someone does `>> clearTimeout + ''` they will see the fake timeout functions bodies. This is probably pure vanity, but I think it is neater to output a pretend native function body.
