### PR TITLE
Added `global` as an alias for the global object in the sandbox context

### DIFF
--- a/ecmabot-utils.js
+++ b/ecmabot-utils.js
@@ -21,6 +21,9 @@ global.print = global.alert = global.console.log;
 
 global.version = typeof version === "undefined" ? "unknown" : version;
 
+Object.defineProperty(global, "global", {
+	value: global
+});
 
 /**
  * Pretty-prints a Javascript value for viewing.


### PR DESCRIPTION
fixes #25 
