### PR TITLE
preventing syntax error

### DIFF
--- a/lib/sandbox/index.js
+++ b/lib/sandbox/index.js
@@ -124,7 +124,7 @@ Sandbox.prototype.runHaskell = function (timeout, code, hollaback, object) {
 						type: lines[1],
 						console: [],
 						obvioustype: false
-					}
+					},
 					error: lines.splice(2, lines.length - 2).join(' '),
 					result: null
 				});


### PR DESCRIPTION
``` 
                                       error: lines.splice(2, lines.length - 2).join(' '),
                                        ^^^^^

SyntaxError: Unexpected identifier
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:374:25)
    at Object.Module._extensions..js (module.js:417:10)
    at Module.load (module.js:344:32)
    at Function.Module._load (module.js:301:12)
    at Module.require (module.js:354:17)
    at require (internal/module.js:12:17)
    at Object.<anonymous> (/home/ubuntu/local_ella/ecmabot.js:6:15)
    at Module._compile (module.js:410:26)
    at Object.Module._extensions..js (module.js:417:10)
```