### PR TITLE
fix for Unforeseen Error: ReferenceError: result is not defined

### DIFF
--- a/shared.js
+++ b/shared.js
@@ -14,7 +14,7 @@ function parse_regex_literal (text) {
 }
 
 
-function cleanReply(text){
+function cleanReply(text, result){
 	text = text
 		.split('\n')
 		.map(function(x){
@@ -172,15 +172,15 @@ var Shared = module.exports = {
 							description: "result of " + context.sender.name + "'s code"
 						})
 						.then(function(url){
-							var fullReply = cleanReply(visibleReply) + " ... " + url;
+							var fullReply = cleanReply(visibleReply, result) + " ... " + url;
 							context.channel.send_reply(context.intent, fullReply, {truncate: false});
 						})
 						.catch(function(err){
-							var fullReply = cleanReply(visibleReply) + " ... <unable to create gist url>";
+							var fullReply = cleanReply(visibleReply, result) + " ... <unable to create gist url>";
 							context.channel.send_reply(context.intent, fullReply, {truncate: false});
 						});
 					} else {
-						context.channel.send_reply(context.intent, cleanReply(reply), {truncate: true});
+						context.channel.send_reply(context.intent, cleanReply(reply, result), {truncate: true});
 					}
 					return;
 				}


### PR DESCRIPTION
I kept getting
```
Unhandled rejection ReferenceError: result is not defined
    at cleanReply (/home/ubuntu/ella2/shared.js:27:15)
    at /home/ubuntu/ella2/shared.js:186:24
    at tryCatcher (/home/ubuntu/ella2/node_modules/bluebird/js/main/util.js:26:23)
    at Promise._settlePromiseFromHandler (/home/ubuntu/ella2/node_modules/bluebird/js/main/promise.js:507:31)
    at Promise._settlePromiseAt (/home/ubuntu/ella2/node_modules/bluebird/js/main/promise.js:581:18)
    at Promise._settlePromises (/home/ubuntu/ella2/node_modules/bluebird/js/main/promise.js:697:14)
    at Async._drainQueue (/home/ubuntu/ella2/node_modules/bluebird/js/main/async.js:123:16)
    at Async._drainQueues (/home/ubuntu/ella2/node_modules/bluebird/js/main/async.js:133:10)
    at Immediate.Async.drainQueues [as _onImmediate] (/home/ubuntu/ella2/node_modules/bluebird/js/main/async.js:15:14)
```

Looks like its referencing a result object which isn't defined,
now i pass it in