### PR TITLE
[fix] `throw null` and `throw undefined` are valid in JS

### DIFF
--- a/oftnbot-utils.js
+++ b/oftnbot-utils.js
@@ -270,7 +270,7 @@ exports.run = function(execute) {
 	try {
 		result = execute();
 	} catch(e) {
-		if (typeof e.name !== "undefined" &&
+		if (e && typeof e.name !== "undefined" &&
 			typeof e.message !== "undefined") {
 			error = e;
 			error.name = e.name; // Weird bug


### PR DESCRIPTION
Currently, this throws with `Internal Error: SpiderMonkey sandbox, TypeError: e is undefined` when you `>> throw undefined`.

This should fix it.